### PR TITLE
Support 3.8 and Default Config

### DIFF
--- a/node/telemetry/heart.py
+++ b/node/telemetry/heart.py
@@ -48,7 +48,7 @@ class Heart:
             # Get all the updated info
             with self._impulse_lock:
                 for metric in self._metrics:
-                    self._data[metric.metric_name()] |= metric.measure()
+                    self._data[metric.metric_name()].update(metric.measure())
                 self._data['time'] = int(time.time())
 
                 self._pulse()

--- a/spd_node.ini
+++ b/spd_node.ini
@@ -1,2 +1,2 @@
-[NETWORK]
-SERVER_IP = 'localhost'
+[SERVER]
+SERVER_IP = 64.227.2.44


### PR DESCRIPTION
Add Support for Python 3.8 (remove new 3.9 dict update operator) and add DO Deploy server as default node publish location